### PR TITLE
Move specials to new module, speedup

### DIFF
--- a/gdxpds/__init__.py
+++ b/gdxpds/__init__.py
@@ -46,6 +46,7 @@ import sys
 logger = logging.getLogger(__name__)
 
 from gdxpds.tools import Error
+from gdxpds.special import load_specials
 
 def load_gdxcc(gams_dir=None):
     """
@@ -67,6 +68,7 @@ def load_gdxcc(gams_dir=None):
     H = gdxcc.new_gdxHandle_tp()
     rc = gdxcc.gdxCreateD(H,finder.gams_dir,gdxcc.GMS_SSSIZE)
     gdxcc.gdxFree(H)
+    load_specials()
     return
 
 try:

--- a/gdxpds/gdx.py
+++ b/gdxpds/gdx.py
@@ -77,6 +77,16 @@ import numpy as np
 import pandas as pds
 
 import gdxpds.special as special
+# Import some things for backward compatibility
+from gdxpds.special import (
+    convert_gdx_to_np_svs,
+    convert_np_to_gdx_svs,
+    gdx_isnan,
+    gdx_val_equal,
+    NUMPY_SPECIAL_VALUES,
+    is_np_eps,
+    is_np_sv,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/gdxpds/gdx.py
+++ b/gdxpds/gdx.py
@@ -76,12 +76,11 @@ import gdxcc
 import numpy as np
 import pandas as pds
 
+from gdxpds.special import NUMPY_SPECIAL_VALUES
+
 logger = logging.getLogger(__name__)
 
 
-# List of numpy special values in gdxGetSpecialValues order
-#                      1E300,  2E300,  3E300,   4E300,               5E300 
-NUMPY_SPECIAL_VALUES = [None, np.nan, np.inf, -np.inf, np.finfo(float).eps]
 
 def convert_gdx_to_np_svs(df,num_dims,gdxf):
     """

--- a/gdxpds/gdx.py
+++ b/gdxpds/gdx.py
@@ -264,11 +264,6 @@ class GdxFile(MutableSequence, NeedsGamsDir):
         if not ret:
             raise GdxError(self.H,"Could not open {} for writing. Consider cloning this file (.clone()) before trying to write".format(repr(filename)))
         self._filename = filename
-
-        # set special values
-        ret = gdxcc.gdxSetSpecialValues(self.H, special.SPECIAL_VALUES)
-        if ret == 0:
-            raise GdxError(self.H,"Unable to set special values")
         
         # write the universal set
         self.universal_set.write()

--- a/gdxpds/special.py
+++ b/gdxpds/special.py
@@ -1,3 +1,39 @@
+# [LICENSE]
+# Copyright (c) 2018, Alliance for Sustainable Energy.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms,
+# with or without modification, are permitted provided
+# that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above
+# copyright notice, this list of conditions and the
+# following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the
+# above copyright notice, this list of conditions and the
+# following disclaimer in the documentation and/or other
+# materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the
+# names of its contributors may be used to endorse or
+# promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+# CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+# INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+# OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# [/LICENSE]
 
 import copy
 import logging

--- a/gdxpds/special.py
+++ b/gdxpds/special.py
@@ -32,12 +32,6 @@ def convert_gdx_to_np_svs(df, num_dims):
         their numpy equivalents
     """
 
-    # single-value mapping function
-    def to_np_svs(value):
-        if value in GDX_TO_NP_SVS:
-            return GDX_TO_NP_SVS[value]
-        return value
-
     # create clean copy of df
     try:
         tmp = copy.deepcopy(df)
@@ -46,7 +40,7 @@ def convert_gdx_to_np_svs(df, num_dims):
         tmp = copy.copy(df)
 
     # apply the map to the value columns and merge with the dimensional information
-    tmp = (tmp.iloc[:, :num_dims]).merge(tmp.iloc[:, num_dims:].applymap(to_np_svs),
+    tmp = (tmp.iloc[:, :num_dims]).merge(tmp.iloc[:, num_dims:].replace(GDX_TO_NP_SVS, value=None),
                                          left_index=True, right_index=True)
     return tmp
 

--- a/gdxpds/special.py
+++ b/gdxpds/special.py
@@ -95,15 +95,11 @@ def convert_np_to_gdx_svs(df, num_dims):
     """
 
     # converts a single value; NANs are assumed already handled
-    def to_gdx_svs(value):
-        # find numpy special values by direct comparison
-        for i, npsv in enumerate(NUMPY_SPECIAL_VALUES):
-            if value == npsv:
-                return NP_TO_GDX_SVS[i]
+    def convert_approx_eps(value):
         # eps values are not always caught by ==, use is_np_eps which applies
         # a tolerance
         if is_np_eps(value):
-            return NP_TO_GDX_SVS[4]
+            return SPECIAL_VALUES[4]
         return value
 
     # get a clean copy of df
@@ -115,7 +111,7 @@ def convert_np_to_gdx_svs(df, num_dims):
 
     # fillna and apply map to value columns, then merge with dimensional columns
     try:
-        values = tmp.iloc[:, num_dims:].fillna(NP_TO_GDX_SVS[1]).applymap(to_gdx_svs)
+        values = tmp.iloc[:, num_dims:].replace(NP_TO_GDX_SVS, value=None).applymap(convert_approx_eps)
         tmp = (tmp.iloc[:, :num_dims]).merge(values, left_index=True, right_index=True)
     except:
         logger.error("Unable to convert numpy special values to GDX special values." + \
@@ -182,7 +178,7 @@ def special_getter():
         special_list.append(special_values[i])
         gdx_val = special_values[i]
         gdx_to_np_svs[gdx_val] = NUMPY_SPECIAL_VALUES[i]
-        np_to_gdx_svs[i] = gdx_val
+        np_to_gdx_svs[NUMPY_SPECIAL_VALUES[i]] = gdx_val
 
     gdxcc.gdxFree(H)
     return special_list, gdx_to_np_svs, np_to_gdx_svs

--- a/gdxpds/special.py
+++ b/gdxpds/special.py
@@ -1,0 +1,206 @@
+
+import copy
+import logging
+
+import gdxcc
+import numpy as np
+
+
+# List of numpy special values in gdxGetSpecialValues order
+#                      1E300,  2E300,  3E300,   4E300,               5E300
+NUMPY_SPECIAL_VALUES = [None, np.nan, np.inf, -np.inf, np.finfo(float).eps]
+
+logger = logging.getLogger(__name__)
+
+
+def convert_gdx_to_np_svs(df, num_dims, gdxf):
+    """
+    Converts GDX special values to the corresponding numpy versions.
+
+    Parmeters
+    ---------
+    df : pandas.DataFrame
+        a GdxSymbol DataFrame as it was read directly from GDX
+    num_dims : int
+        the number of columns in df that list the dimension values for which the
+        symbol value is non-zero / non-default
+    gdxf : GdxFile
+        the GdxFile containing the symbol. Used to provide the gdx_to_np_svs map.
+
+    Returns
+    -------
+    pandas.DataFrame
+        copy of df for which all GDX special values have been converted to
+        their numpy equivalents
+    """
+
+    # single-value mapping function
+    def to_np_svs(value):
+        if value in gdxf.gdx_to_np_svs:
+            return gdxf.gdx_to_np_svs[value]
+        return value
+
+    # create clean copy of df
+    try:
+        tmp = copy.deepcopy(df)
+    except:
+        logger.warning("Unable to deepcopy:\n{}".format(df))
+        tmp = copy.copy(df)
+
+    # apply the map to the value columns and merge with the dimensional information
+    tmp = (tmp.iloc[:, :num_dims]).merge(tmp.iloc[:, num_dims:].applymap(to_np_svs),
+                                         left_index=True, right_index=True)
+    return tmp
+
+
+def is_np_eps(val):
+    """
+    Parameters
+    ----------
+    val : numeric
+        value to test
+
+    Returns
+    -------
+    bool
+        True if val is equal to eps (np.finfo(float).eps), False otherwise
+    """
+    return np.abs(val - NUMPY_SPECIAL_VALUES[-1]) < NUMPY_SPECIAL_VALUES[-1]
+
+
+def is_np_sv(val):
+    """
+    Parameters
+    ----------
+    val : numeric
+        value to test
+
+    Returns
+    -------
+    bool
+        True if val is NaN, eps, or is in NUMPY_SPECIAL_VALUES; False otherwise
+    """
+    return np.isnan(val) or (val in NUMPY_SPECIAL_VALUES) or is_np_eps(val)
+
+
+def convert_np_to_gdx_svs(df, num_dims, gdxf):
+    """
+    Converts numpy special values to the corresponding GDX versions.
+
+    Parmeters
+    ---------
+    df : pandas.DataFrame
+        a GdxSymbol DataFrame in pandas/numpy form
+    num_dims : int
+        the number of columns in df that list the dimension values for which the
+        symbol value is non-zero / non-default
+    gdxf : GdxFile
+        the GdxFile containing the symbol. Used to provide the np_to_gdx_svs map.
+
+    Returns
+    -------
+    pandas.DataFrame
+        copy of df for which all numpy special values have been converted to
+        their GDX equivalents
+    """
+
+    # converts a single value; NANs are assumed already handled
+    def to_gdx_svs(value):
+        # find numpy special values by direct comparison
+        for i, npsv in enumerate(NUMPY_SPECIAL_VALUES):
+            if value == npsv:
+                return gdxf.np_to_gdx_svs[i]
+        # eps values are not always caught by ==, use is_np_eps which applies
+        # a tolerance
+        if is_np_eps(value):
+            return gdxf.np_to_gdx_svs[4]
+        return value
+
+    # get a clean copy of df
+    try:
+        tmp = copy.deepcopy(df)
+    except:
+        logger.warning("Unable to deepcopy:\n{}".format(df))
+        tmp = copy.copy(df)
+
+    # fillna and apply map to value columns, then merge with dimensional columns
+    try:
+        values = tmp.iloc[:, num_dims:].fillna(gdxf.np_to_gdx_svs[1]).applymap(to_gdx_svs)
+        tmp = (tmp.iloc[:, :num_dims]).merge(values, left_index=True, right_index=True)
+    except:
+        logger.error("Unable to convert numpy special values to GDX special values." + \
+                     "num_dims: {}, dataframe:\n{}".format(num_dims, df))
+        raise
+    return tmp
+
+
+def gdx_isnan(val, gdxf):
+    """
+    Utility function for equating the GDX special values that map to None or NaN
+    (which are indistinguishable in pandas).
+
+    Parameters
+    ----------
+    val : numeric
+        value to test
+    gdxf : GdxFile
+        GDX file containing the value. Provides np_to_gdx_svs map.
+
+    Returns
+    -------
+    bool
+        True if val is a GDX encoded special value that maps to None or numpy.nan;
+        False otherwise
+    """
+    return val in [gdxf.np_to_gdx_svs[0], gdxf.np_to_gdx_svs[1]]
+
+
+def gdx_val_equal(val1, val2, gdxf):
+    """
+    Utility function used to test special value conversions.
+
+    Parameters
+    ----------
+    val1 : float or GDX special value
+        first value to compare
+    val2 : float or GDX special value
+        second value to compare
+    gdxf : GdxFile
+        GDX file containing val1 and val2
+
+    Returns
+    -------
+    bool
+        True if val1 and val2 are equal in the sense of == or they are
+        equivalent GDX-format special values. The values that map to None
+        and np.nan are assumed to be equal because pandas cannot be relied
+        upon to make the distinction.
+    """
+    if gdx_isnan(val1, gdxf) and gdx_isnan(val2, gdxf):
+        return True
+    return val1 == val2
+
+
+def special_getter():
+    H = gdxcc.new_gdxHandle_tp()
+    rc = gdxcc.gdxCreateD(H, None, gdxcc.GMS_SSSIZE)
+    if not rc:
+        raise Exception(rc[1])
+    # get special values
+    special_values = gdxcc.doubleArray(gdxcc.GMS_SVIDX_MAX)
+    gdxcc.gdxGetSpecialValues(H, special_values)
+
+    gdx_to_np_svs = {}
+    np_to_gdx_svs = {}
+    for i in range(gdxcc.GMS_SVIDX_MAX):
+        if i >= len(NUMPY_SPECIAL_VALUES):
+            break
+        gdx_val = special_values[i]
+        gdx_to_np_svs[gdx_val] = NUMPY_SPECIAL_VALUES[i]
+        np_to_gdx_svs[i] = gdx_val
+
+    gdxcc.gdxFree(H)
+    return gdx_to_np_svs, np_to_gdx_svs
+
+
+GDX_TO_NP_SVS, NP_TO_GDX_SVS = special_getter()

--- a/gdxpds/special.py
+++ b/gdxpds/special.py
@@ -196,6 +196,53 @@ def pd_val_equal(val1, val2):
     return pd_isnan(val1) and pd_isnan(val2) or val1 == val2
 
 
+def gdx_isnan(val,gdxf):
+    """
+    Utility function for equating the GDX special values that map to None or NaN
+    (which are indistinguishable in pandas).
+
+    Parameters
+    ----------
+    val : numeric
+        value to test
+    gdxf : GdxFile
+        GDX file containing the value. Provides np_to_gdx_svs map.
+
+    Returns
+    -------
+    bool
+        True if val is a GDX encoded special value that maps to None or numpy.nan;
+        False otherwise
+    """
+    return val in [SPECIAL_VALUES[0], SPECIAL_VALUES[1]]
+
+
+def gdx_val_equal(val1,val2,gdxf):
+    """
+    Utility function used to test special value conversions.
+
+    Parameters
+    ----------
+    val1 : float or GDX special value
+        first value to compare
+    val2 : float or GDX special value
+        second value to compare
+    gdxf : GdxFile
+        GDX file containing val1 and val2
+
+    Returns
+    -------
+    bool
+        True if val1 and val2 are equal in the sense of == or they are
+        equivalent GDX-format special values. The values that map to None
+        and np.nan are assumed to be equal because pandas cannot be relied
+        upon to make the distinction.
+    """
+    if gdx_isnan(val1, gdxf) and gdx_isnan(val2, gdxf):
+        return True
+    return val1 == val2
+
+
 def special_getter():
     H = gdxcc.new_gdxHandle_tp()
     rc = gdxcc.gdxCreateD(H, None, gdxcc.GMS_SSSIZE)

--- a/gdxpds/special.py
+++ b/gdxpds/special.py
@@ -243,7 +243,11 @@ def gdx_val_equal(val1,val2,gdxf):
     return val1 == val2
 
 
-def special_getter():
+def load_specials():
+    global SPECIAL_VALUES
+    global GDX_TO_NP_SVS
+    global NP_TO_GDX_SVS
+
     H = gdxcc.new_gdxHandle_tp()
     rc = gdxcc.gdxCreateD(H, None, gdxcc.GMS_SSSIZE)
     if not rc:
@@ -252,19 +256,21 @@ def special_getter():
     special_values = gdxcc.doubleArray(gdxcc.GMS_SVIDX_MAX)
     gdxcc.gdxGetSpecialValues(H, special_values)
 
-    special_list = []
-    gdx_to_np_svs = {}
-    np_to_gdx_svs = {}
+    SPECIAL_VALUES = []
+    GDX_TO_NP_SVS = {}
+    NP_TO_GDX_SVS = {}
     for i in range(gdxcc.GMS_SVIDX_MAX):
         if i >= len(NUMPY_SPECIAL_VALUES):
             break
-        special_list.append(special_values[i])
+        SPECIAL_VALUES.append(special_values[i])
         gdx_val = special_values[i]
-        gdx_to_np_svs[gdx_val] = NUMPY_SPECIAL_VALUES[i]
-        np_to_gdx_svs[NUMPY_SPECIAL_VALUES[i]] = gdx_val
+        GDX_TO_NP_SVS[gdx_val] = NUMPY_SPECIAL_VALUES[i]
+        NP_TO_GDX_SVS[NUMPY_SPECIAL_VALUES[i]] = gdx_val
 
     gdxcc.gdxFree(H)
-    return special_list, gdx_to_np_svs, np_to_gdx_svs
 
 
-SPECIAL_VALUES, GDX_TO_NP_SVS, NP_TO_GDX_SVS = special_getter()
+# These values are populated by load_specials, called in load_gdxcc
+SPECIAL_VALUES = []
+GDX_TO_NP_SVS = {}
+NP_TO_GDX_SVS = {}

--- a/gdxpds/special.py
+++ b/gdxpds/special.py
@@ -176,17 +176,19 @@ def special_getter():
     special_values = gdxcc.doubleArray(gdxcc.GMS_SVIDX_MAX)
     gdxcc.gdxGetSpecialValues(H, special_values)
 
+    special_list = []
     gdx_to_np_svs = {}
     np_to_gdx_svs = {}
     for i in range(gdxcc.GMS_SVIDX_MAX):
         if i >= len(NUMPY_SPECIAL_VALUES):
             break
+        special_list.append(special_values[i])
         gdx_val = special_values[i]
         gdx_to_np_svs[gdx_val] = NUMPY_SPECIAL_VALUES[i]
         np_to_gdx_svs[i] = gdx_val
 
     gdxcc.gdxFree(H)
-    return special_values, gdx_to_np_svs, np_to_gdx_svs
+    return special_list, gdx_to_np_svs, np_to_gdx_svs
 
 
 SPECIAL_VALUES, GDX_TO_NP_SVS, NP_TO_GDX_SVS = special_getter()

--- a/gdxpds/special.py
+++ b/gdxpds/special.py
@@ -192,7 +192,7 @@ def special_getter():
         np_to_gdx_svs[i] = gdx_val
 
     gdxcc.gdxFree(H)
-    return gdx_to_np_svs, np_to_gdx_svs
+    return special_values, gdx_to_np_svs, np_to_gdx_svs
 
 
-GDX_TO_NP_SVS, NP_TO_GDX_SVS = special_getter()
+SPECIAL_VALUES, GDX_TO_NP_SVS, NP_TO_GDX_SVS = special_getter()

--- a/gdxpds/special.py
+++ b/gdxpds/special.py
@@ -124,10 +124,9 @@ def convert_np_to_gdx_svs(df, num_dims):
     return tmp
 
 
-def gdx_isnan(val):
+def pd_isnan(val):
     """
-    Utility function for equating the GDX special values that map to None or NaN
-    (which are indistinguishable in pandas).
+    Utility function for identifying None or NaN (which are indistinguishable in pandas).
 
     Parameters
     ----------
@@ -140,31 +139,29 @@ def gdx_isnan(val):
         True if val is a GDX encoded special value that maps to None or numpy.nan;
         False otherwise
     """
-    return val in [NP_TO_GDX_SVS[0], NP_TO_GDX_SVS[1]]
+    return val is None or val != val
 
 
-def gdx_val_equal(val1, val2):
+def pd_val_equal(val1, val2):
     """
     Utility function used to test special value conversions.
 
     Parameters
     ----------
-    val1 : float or GDX special value
+    val1 : float or None
         first value to compare
-    val2 : float or GDX special value
+    val2 : float or None
         second value to compare
 
     Returns
     -------
     bool
         True if val1 and val2 are equal in the sense of == or they are
-        equivalent GDX-format special values. The values that map to None
-        and np.nan are assumed to be equal because pandas cannot be relied
-        upon to make the distinction.
+        both NaN/None. The values that map to None and np.nan are assumed
+        to be equal because pandas cannot be relied upon to make the
+        distinction.
     """
-    if gdx_isnan(val1) and gdx_isnan(val2):
-        return True
-    return val1 == val2
+    return pd_isnan(val1) and pd_isnan(val2) or val1 == val2
 
 
 def special_getter():

--- a/gdxpds/special.py
+++ b/gdxpds/special.py
@@ -244,6 +244,11 @@ def gdx_val_equal(val1,val2,gdxf):
 
 
 def load_specials():
+    """
+    Load special values
+
+    Needs to be called after gdxcc is loaded.
+    """
     global SPECIAL_VALUES
     global GDX_TO_NP_SVS
     global NP_TO_GDX_SVS

--- a/gdxpds/test/test_details.py
+++ b/gdxpds/test/test_details.py
@@ -42,6 +42,7 @@ import os
 import subprocess as subp
 
 import gdxpds.gdx
+import gdxpds.special
 from gdxpds.test import base_dir, run_dir
 from gdxpds.test.test_session import manage_rundir
 from gdxpds.test.test_conversions import roundtrip_one_gdx
@@ -65,7 +66,7 @@ def test_roundtrip_just_special_values(manage_rundir):
         os.mkdir(outdir)
     # create gdx file containing all special values
     with gdxpds.gdx.GdxFile() as f:
-        df = pds.DataFrame([['sv' + str(i+1), f.special_values[i]] for i in range(gdxcc.GMS_SVIDX_MAX-2)],
+        df = pds.DataFrame([['sv' + str(i+1), gdxpds.special.SPECIAL_VALUES[i]] for i in range(gdxcc.GMS_SVIDX_MAX-2)],
                            columns=['sv','Value'])
         logger.info("Special values are:\n{}".format(df))
 
@@ -104,7 +105,7 @@ def test_roundtrip_just_special_values(manage_rundir):
     def check_special_values(gdx_file):
         df = gdx_file['special_values'].dataframe
         for i, val in enumerate(df['Value'].values):
-            assert gdxpds.gdx.gdx_val_equal(gdx_file.np_to_gdx_svs[i],gdx_file.special_values[i],gdx_file)
+            assert gdxpds.special.gdx_val_equal(gdxpds.special.NP_TO_GDX_SVS[i],gdxpds.special.SPECIAL_VALUES[i])
 
     # now roundtrip it gdx-only
     with gdxpds.gdx.GdxFile(lazy_load=False) as f:
@@ -136,12 +137,12 @@ def test_roundtrip_special_values(manage_rundir):
             sym = gdx['calculate_capacity_value']
             assert sym.data_type == gdxpds.gdx.GamsDataType.Equation
             val = sym.dataframe.iloc[0,value_column_index(sym,gdxpds.gdx.GamsValueType.Marginal)]
-            assert gdxpds.gdx.is_np_sv(val)
+            assert gdxpds.special.is_np_sv(val)
             data[-1].append(val)
             sym = gdx['CapacityValue']
             assert sym.data_type == gdxpds.gdx.GamsDataType.Variable
             val = sym.dataframe.iloc[0,value_column_index(sym,gdxpds.gdx.GamsValueType.Upper)]
-            assert gdxpds.gdx.is_np_sv(val)
+            assert gdxpds.special.is_np_sv(val)
             data[-1].append(val)
     data = list(zip(*data))
     for pt in data:
@@ -173,9 +174,9 @@ def test_from_scratch_sets(manage_rundir):
             assert isinstance(sym.dataframe[sym.dataframe.columns[-1]].values[0],c_bool)
 
 def test_numpy_eps():
-    assert(gdxpds.gdx.is_np_eps(np.finfo(float).eps))
-    assert(not gdxpds.gdx.is_np_eps(float(0.0)))
-    assert(not gdxpds.gdx.is_np_eps(2.0 * np.finfo(float).eps))
+    assert(gdxpds.special.is_np_eps(np.finfo(float).eps))
+    assert(not gdxpds.special.is_np_eps(float(0.0)))
+    assert(not gdxpds.special.is_np_eps(2.0 * np.finfo(float).eps))
 
 def test_unnamed_dimensions(manage_rundir):
     outdir = os.path.join(run_dir,'unnamed_dimensions')

--- a/gdxpds/test/test_details.py
+++ b/gdxpds/test/test_details.py
@@ -75,10 +75,6 @@ def test_roundtrip_just_special_values(manage_rundir):
         ret = gdxcc.gdxOpenWrite(f.H,filename,"gdxpds")
         if not ret:
             raise gdxpds.gdx.GdxError(f.H,"Could not open {} for writing. Consider cloning this file (.clone()) before trying to write".format(repr(filename)))
-        # set special values
-        ret = gdxcc.gdxSetSpecialValues(f.H,f.special_values)
-        if ret == 0:
-            raise gdxpds.gdx.GdxError(f.H,"Unable to set special values")
         # write the universal set
         f.universal_set.write()
         if not gdxcc.gdxDataWriteStrStart(f.H,

--- a/gdxpds/test/test_details.py
+++ b/gdxpds/test/test_details.py
@@ -177,11 +177,11 @@ def test_special_integrity():
     assert all(sv in gdxpds.special.NP_TO_GDX_SVS for sv in gdxpds.special.NUMPY_SPECIAL_VALUES)
 
     for val in gdxpds.special.SPECIAL_VALUES:
-        assert gdxpds.special.NP_TO_GDX_SVS(gdxpds.special.GDX_TO_NP_SVS[val]) == val
+        assert gdxpds.special.NP_TO_GDX_SVS[gdxpds.special.GDX_TO_NP_SVS[val]] == val
 
     for val in gdxpds.special.NUMPY_SPECIAL_VALUES:
         # Can't use "==", as None != NaN
-        assert gdxpds.special.pd_val_equal(gdxpds.special.GDX_TO_NP_SVS(gdxpds.special.NP_TO_GDX_SVS[val]), val)
+        assert gdxpds.special.pd_val_equal(gdxpds.special.GDX_TO_NP_SVS[gdxpds.special.NP_TO_GDX_SVS[val]], val)
 
 def test_numpy_eps():
     assert(gdxpds.special.is_np_eps(np.finfo(float).eps))

--- a/gdxpds/test/test_details.py
+++ b/gdxpds/test/test_details.py
@@ -169,7 +169,7 @@ def test_from_scratch_sets(manage_rundir):
             assert sym.num_records == 10
             assert isinstance(sym.dataframe[sym.dataframe.columns[-1]].values[0],c_bool)
 
-def check_special_integrity():
+def test_special_integrity():
     """
     Check that the special values line up
     """

--- a/gdxpds/test/test_details.py
+++ b/gdxpds/test/test_details.py
@@ -101,7 +101,7 @@ def test_roundtrip_just_special_values(manage_rundir):
     def check_special_values(gdx_file):
         df = gdx_file['special_values'].dataframe
         for i, val in enumerate(df['Value'].values):
-            assert gdxpds.special.gdx_val_equal(gdxpds.special.NP_TO_GDX_SVS[i],gdxpds.special.SPECIAL_VALUES[i])
+            assert gdxpds.special.pd_val_equal(val, gdxpds.special.NUMPY_SPECIAL_VALUES[i])
 
     # now roundtrip it gdx-only
     with gdxpds.gdx.GdxFile(lazy_load=False) as f:
@@ -168,6 +168,10 @@ def test_from_scratch_sets(manage_rundir):
             assert sym.data_type == gdxpds.gdx.GamsDataType.Set
             assert sym.num_records == 10
             assert isinstance(sym.dataframe[sym.dataframe.columns[-1]].values[0],c_bool)
+
+def check_special_integrity():
+    for i, val in enumerate(gdxpds.special.SPECIAL_VALUES):
+        assert gdxpds.special.NP_TO_GDX_SVS[i] == val
 
 def test_numpy_eps():
     assert(gdxpds.special.is_np_eps(np.finfo(float).eps))

--- a/gdxpds/test/test_details.py
+++ b/gdxpds/test/test_details.py
@@ -170,8 +170,18 @@ def test_from_scratch_sets(manage_rundir):
             assert isinstance(sym.dataframe[sym.dataframe.columns[-1]].values[0],c_bool)
 
 def check_special_integrity():
-    for i, val in enumerate(gdxpds.special.SPECIAL_VALUES):
-        assert gdxpds.special.NP_TO_GDX_SVS[i] == val
+    """
+    Check that the special values line up
+    """
+    assert all(sv in gdxpds.special.GDX_TO_NP_SVS for sv in gdxpds.special.SPECIAL_VALUES)
+    assert all(sv in gdxpds.special.NP_TO_GDX_SVS for sv in gdxpds.special.NUMPY_SPECIAL_VALUES)
+
+    for val in gdxpds.special.SPECIAL_VALUES:
+        assert gdxpds.special.NP_TO_GDX_SVS(gdxpds.special.GDX_TO_NP_SVS[val]) == val
+
+    for val in gdxpds.special.NUMPY_SPECIAL_VALUES:
+        # Can't use "==", as None != NaN
+        assert gdxpds.special.pd_val_equal(gdxpds.special.GDX_TO_NP_SVS(gdxpds.special.NP_TO_GDX_SVS[val]), val)
 
 def test_numpy_eps():
     assert(gdxpds.special.is_np_eps(np.finfo(float).eps))


### PR DESCRIPTION
Move code handling special values into a separate file out of the GDX class. We now precalculate SPECIAL_VALUES and NUMPY_SPECIAL_VALUES (lists of special values), GDX_TO_NP_SVS and NP_TO_GDX_SVS (dictionaries which do conversions between the GDX world and the Python world and back).

I also tried to speedup the convert_np_to_gdx_svs/convert_gdx_to_np_svs functions and I will verify this in a bit.