### PR TITLE
Gams where

### DIFF
--- a/gdxpds/tools.py
+++ b/gdxpds/tools.py
@@ -109,40 +109,39 @@ class GamsDirFinder(object):
         """
         # check for environment variable
         ret = os.environ.get('GAMS_DIR')
-        
-        if ret is None:
-            if os.name == 'nt':
-                # windows systems
-                # search in default installation location
-                cur_dir = r'C:\GAMS'
-                if os.path.exists(cur_dir):
-                    # level 1 - prefer win64 to win32
-                    for p, dirs, files in os.walk(cur_dir):
-                        if 'win64' in dirs:
-                            cur_dir = os.path.join(cur_dir, 'win64')
-                        elif len(dirs) > 0:
-                            cur_dir = os.path.join(cur_dir, dirs[0])
-                        else:
-                            return ret
-                        break
-                if os.path.exists(cur_dir):
-                    # level 2 - prefer biggest number (most recent version)
-                    for p, dirs, files in os.walk(cur_dir):
-                        if len(dirs) > 1:
-                            try:
-                                versions = [float(x) for x in dirs]
-                                ret = os.path.join(cur_dir, "{}".format(max(versions)))
-                            except:
-                                ret = os.path.join(cur_dir, dirs[0])
-                        elif len(dirs) > 0:
+
+        if ret is None and os.name == 'nt':
+            # search in default installation location
+            cur_dir = r'C:\GAMS'
+            if os.path.exists(cur_dir):
+                # level 1 - prefer win64 to win32
+                for p, dirs, files in os.walk(cur_dir):
+                    if 'win64' in dirs:
+                        cur_dir = os.path.join(cur_dir, 'win64')
+                    elif len(dirs) > 0:
+                        cur_dir = os.path.join(cur_dir, dirs[0])
+                    else:
+                        return ret
+                    break
+            if os.path.exists(cur_dir):
+                # level 2 - prefer biggest number (most recent version)
+                for p, dirs, files in os.walk(cur_dir):
+                    if len(dirs) > 1:
+                        try:
+                            versions = [float(x) for x in dirs]
+                            ret = os.path.join(cur_dir, "{}".format(max(versions)))
+                        except:
                             ret = os.path.join(cur_dir, dirs[0])
-                        break
-            else:
-                # posix systems
-                try:
-                    ret = os.path.dirname(subp.check_output(['which', 'gams'])).decode()
-                except:
-                    ret = None
+                    elif len(dirs) > 0:
+                        ret = os.path.join(cur_dir, dirs[0])
+                    break
+
+        if ret is None and os.name != 'nt':
+            # posix systems
+            try:
+                ret = os.path.dirname(subp.check_output(['which', 'gams'])).decode()
+            except:
+                ret = None
                 
         if ret is not None:
             ret = self.__clean_gams_dir(ret)

--- a/gdxpds/tools.py
+++ b/gdxpds/tools.py
@@ -113,7 +113,7 @@ class GamsDirFinder(object):
         if ret is None and os.name == 'nt':
             # windows systems
             try:
-                ret = os.path.dirname(subp.check_output(['where', 'gams'])).decode()
+                ret = os.path.dirname(subp.check_output(['where', 'gams']).decode().split("\n")[0])
             except:
                 ret = None
 

--- a/gdxpds/tools.py
+++ b/gdxpds/tools.py
@@ -111,6 +111,13 @@ class GamsDirFinder(object):
         ret = os.environ.get('GAMS_DIR')
 
         if ret is None and os.name == 'nt':
+            # windows systems
+            try:
+                ret = os.path.dirname(subp.check_output(['where', 'gams'])).decode()
+            except:
+                ret = None
+
+        if ret is None and os.name == 'nt':
             # search in default installation location
             cur_dir = r'C:\GAMS'
             if os.path.exists(cur_dir):


### PR DESCRIPTION
Use the windows command "where" to look for GAMS before looking in directories.

This is similar to the unix command "which". This is useful in the cases where we have a non-standard install location or multiple GAMS installs (where one of which is on the path) or an uninstalled version of GAMS (which doesn't actually remove the folder, just the contents)

## Tests
* If gams.exe is not on the path, we then search `C:/GAMS...`
* If gams.exe is in PATH but there are multiple install folders, correctly finds the right folder
* If multiple gams.exe are on the path, the first one returned by "where gams" is chosen