### PR TITLE
Prevent memory leak

### DIFF
--- a/gdxpds/gdx.py
+++ b/gdxpds/gdx.py
@@ -156,7 +156,7 @@ class GdxFile(MutableSequence, NeedsGamsDir):
         self.universal_set = GdxSymbol('*',GamsDataType.Set,dims=1,file=None,index=0)
         self.universal_set._file = self
 
-        atexit.register(self.cleanup)
+        atexit.register(gdxcc.gdxFree, self.H)
         return
 
     def cleanup(self):


### PR DESCRIPTION
If atexit knows what "self" is here, it stores the entire GDX object until the python instance ends.

This works as long as _H doesn't change during execution (this is currently guaranteed due to the lack of a setter for H).

Running the first snippet on 78 doesn't have a RAM usage increasing over time if this change is applied.

Closes #78 