### PR TITLE
GdxSymbol constructors and lazy loading

### DIFF
--- a/gdxpds/gdx.py
+++ b/gdxpds/gdx.py
@@ -488,7 +488,6 @@ class GdxSymbol(object):
         self._dataframe = None; self._dims = None
         self._file = file
         self._index = index
-        self._loaded = False
         self._num_records = None
         if dataframe is not None:
             # Load symbol from dataframe
@@ -687,7 +686,7 @@ class GdxSymbol(object):
 
     @property
     def loaded(self):
-        return self._loaded
+        return self._dataframe is not None
 
     @property
     def full_typename(self):
@@ -791,7 +790,6 @@ class GdxSymbol(object):
                 self._append_default_values(df)
             df.columns = self.dims + self.value_col_names
             self._dataframe = df
-            self._loaded = True
         except Exception:
             logger.error("Unable to set dataframe for {} to\n{}\n\nIn process dataframe: {}".format(self,data,self._dataframe))
             raise
@@ -876,7 +874,6 @@ class GdxSymbol(object):
 
         if self.data_type == GamsDataType.Parameter and HAVE_GDX2PY:
             self.dataframe = gdx2py.par2list(self.file.filename,self.name) 
-            self._loaded = True
             return
 
         data = []
@@ -891,12 +888,10 @@ class GdxSymbol(object):
         self.dataframe = data
         if not self.data_type == GamsDataType.Set:
             self.dataframe = special.convert_gdx_to_np_svs(self.dataframe, self.num_dims)
-        self._loaded = True
         return
 
     def unload(self):
         self.dataframe = None
-        self._loaded = False
 
     def write(self,index=None): 
         if not self.loaded:

--- a/gdxpds/gdx.py
+++ b/gdxpds/gdx.py
@@ -891,7 +891,7 @@ class GdxSymbol(object):
         return
 
     def unload(self):
-        self.dataframe = None
+        self._dataframe = None
 
     def write(self,index=None): 
         if not self.loaded:

--- a/gdxpds/gdx.py
+++ b/gdxpds/gdx.py
@@ -882,9 +882,6 @@ class GdxSymbol(object):
         if not self.loaded:
             raise Error("Cannot write unloaded symbol {}.".format(repr(self.name)))
 
-        if self.data_type == GamsDataType.Set:
-            self._fixup_set_value()
-
         if index is not None:
             self._index = index
 

--- a/gdxpds/gdx.py
+++ b/gdxpds/gdx.py
@@ -305,6 +305,9 @@ class GdxFile(MutableSequence, NeedsGamsDir):
         self._filename = filename
         
         # write the universal set
+        # This package currently can't recalculate the universal set yet
+        # Therefore unload empty set
+        self.universal_set.dataframe = pds.DataFrame({"*": [], "Value": []})
         self.universal_set.write()
 
         for i, symbol in enumerate(self,start=1):
@@ -485,7 +488,7 @@ class GdxSymbol(object):
         self._dataframe = None; self._dims = None
         self._file = file
         self._index = index
-        self._loaded = index == 0  # Universal set is always loaded
+        self._loaded = False
         self._num_records = None
         if (dataframe is not None):
             # Writing symbol
@@ -810,6 +813,9 @@ class GdxSymbol(object):
         self.dataframe['Value'] = True.
         """
         assert self.data_type == GamsDataType.Set
+        if not self.loaded:
+            # Nothing to fixup
+            return
 
         colname = self._dataframe.columns[-1]
         assert colname == self.value_col_names[0], f"Unexpected final column {colname!r} in Set dataframe"

--- a/gdxpds/gdx.py
+++ b/gdxpds/gdx.py
@@ -538,7 +538,6 @@ class GdxSymbol(object):
         data_type, num_dims = infer_data_type(symbol_name, df)
         logger.info("Inferred data type of {} to be {}.".format(symbol_name,data_type.name))
         symbol = GdxSymbol(symbol_name,data_type,dataframe=df)
-        symbol.dataframe = df
         return symbol
 
     def clone(self):

--- a/gdxpds/gdx.py
+++ b/gdxpds/gdx.py
@@ -524,6 +524,14 @@ class GdxSymbol(object):
 
         return symbol
 
+    @classmethod
+    def from_df(cls, symbol_name, df):
+        data_type, num_dims = infer_data_type(symbol_name, df)
+        logger.info("Inferred data type of {} to be {}.".format(symbol_name,data_type.name))
+        symbol = GdxSymbol(symbol_name,data_type,dims=num_dims)
+        symbol.dataframe = df
+        return symbol
+
     def clone(self):
         if not self.loaded:
             raise Error("Symbol {} cannot be cloned because it is not yet loaded.".format(repr(self.name)))

--- a/gdxpds/gdx.py
+++ b/gdxpds/gdx.py
@@ -725,7 +725,7 @@ class GdxSymbol(object):
     @property
     def dataframe(self):
         if not self.loaded:
-            self.load()
+            raise Error("GdxSymbol not loaded yet. Either .load() from file or assign to .dataframe")
         return self._dataframe
 
     @dataframe.setter

--- a/gdxpds/gdx.py
+++ b/gdxpds/gdx.py
@@ -591,7 +591,6 @@ class GdxSymbol(object):
         self._data_type = GamsDataType(value)
         self.variable_type = None
         self.equation_type = None
-        self._init_dataframe()
         return
 
     @property
@@ -712,7 +711,6 @@ class GdxSymbol(object):
             return
         if isinstance(value, int):
             self._dims = ['*'] * value
-            self._init_dataframe()
             return
         if not isinstance(value, list):
             raise Error('dims must be an int or a list. Was passed {} of type {}.'.format(value, type(value)))
@@ -724,7 +722,6 @@ class GdxSymbol(object):
         if self.loaded and self.num_records > 0:
             self._dataframe.columns = self.dims + self.value_col_names
             return
-        self._init_dataframe()
 
     @property
     def num_dims(self):
@@ -796,13 +793,6 @@ class GdxSymbol(object):
 
         if self.data_type == GamsDataType.Set:
             self._fixup_set_value()
-        return
-
-    def _init_dataframe(self):
-        self._dataframe = pds.DataFrame([],columns=self.dims + self.value_col_names)
-        if self.data_type == GamsDataType.Set:
-            colname = self._dataframe.columns[-1]
-            replace_df_column(self._dataframe,colname,self._dataframe[colname].astype(c_bool))
         return
 
     def _append_default_values(self,df):

--- a/gdxpds/gdx.py
+++ b/gdxpds/gdx.py
@@ -720,6 +720,8 @@ class GdxSymbol(object):
 
     @property
     def dataframe(self):
+        if not self.loaded:
+            self.load()
         return self._dataframe
 
     @dataframe.setter

--- a/gdxpds/gdx.py
+++ b/gdxpds/gdx.py
@@ -478,7 +478,7 @@ GAMS_VARIABLE_DEFAULT_LOWER_UPPER_BOUNDS = {
 }
 
 class GdxSymbol(object): 
-    def __init__(self,name,data_type,dims=None,num_records=None,dataframe=None,file=None,index=None,
+    def __init__(self,name,data_type,dims=None,num_records=None,file=None,index=None,
                  description='',variable_type=None,equation_type=None): 
         self._name = name
         self.description = description
@@ -488,17 +488,9 @@ class GdxSymbol(object):
         self._dataframe = None; self._dims = None
         self._file = file
         self._index = index
-        self._num_records = None
-        if dataframe is not None:
-            # Load symbol from dataframe
-            if dims is not None or num_records is not None:
-                raise ValueError("Do not pass both 'dataframe' and 'dims'/'num_records'")
-            self.dataframe = dataframe
-        else:
-            # Can't load symbol from dataframe, for now lazy load
-            # Can assign to .dataframe later or .load() from file
-            self.dims = dims
-            self._num_records = num_records
+        self.dims = dims
+        self._num_records = num_records
+        # Can now assign to .dataframe or .load() from file
 
     @classmethod
     def from_gdx(cls, file, index):
@@ -548,11 +540,11 @@ class GdxSymbol(object):
         symbol = GdxSymbol(
             symbol_name,
             data_type,
-            dataframe=df,
             description=description,
             variable_type=variable_type,
             equation_type=equation_type,
         )
+        symbol.dataframe = df
         return symbol
 
     def clone(self):

--- a/gdxpds/gdx.py
+++ b/gdxpds/gdx.py
@@ -490,19 +490,22 @@ class GdxSymbol(object):
         self._index = index
         self._loaded = False
         self._num_records = None
-        if (dataframe is not None):
-            # Writing symbol
+        if dataframe is not None:
+            # Load symbol from dataframe
             if dims is not None or num_records is not None:
                 raise ValueError("Do not pass both 'dataframe' and 'dims'/'num_records'")
             self.dataframe = dataframe
         else:
-            # Reading symbol
-            # Do so lazily
+            # Can't load symbol from dataframe, for now lazy load
+            # Can assign to .dataframe later or .load() from file
             self.dims = dims
             self._num_records = num_records
 
     @classmethod
     def from_gdx(cls, file, index):
+        """
+        Helper function safely constructing a GdxSymbol from a file
+        """
         # ... for the symbols
         ret, name, dims, data_type = gdxcc.gdxSymbolInfo(file.H, index)
         if ret != 1:
@@ -537,10 +540,20 @@ class GdxSymbol(object):
         return symbol
 
     @classmethod
-    def from_df(cls, symbol_name, df):
+    def from_df(cls, symbol_name, df, description='', variable_type=None, equation_type=None):
+        """
+        Helper function constructing a GdxSymbol from a Pandas DataFrame
+        """
         data_type, num_dims = infer_data_type(symbol_name, df)
         logger.info("Inferred data type of {} to be {}.".format(symbol_name,data_type.name))
-        symbol = GdxSymbol(symbol_name,data_type,dataframe=df)
+        symbol = GdxSymbol(
+            symbol_name,
+            data_type,
+            dataframe=df,
+            description=description,
+            variable_type=variable_type,
+            equation_type=equation_type,
+        )
         return symbol
 
     def clone(self):

--- a/gdxpds/gdx.py
+++ b/gdxpds/gdx.py
@@ -479,7 +479,6 @@ class GdxSymbol(object):
                  description='',variable_type=None,equation_type=None): 
         self._name = name
         self.description = description
-        self._loaded = False
         self._data_type = GamsDataType(data_type)
         self._variable_type = None; self.variable_type = variable_type
         self._equation_type = None; self.equation_type = equation_type
@@ -531,7 +530,6 @@ class GdxSymbol(object):
         else:
             # universal set
             assert index == 0
-            symbol._loaded = True
 
         return symbol
 

--- a/gdxpds/test/test_read.py
+++ b/gdxpds/test/test_read.py
@@ -71,14 +71,20 @@ def test_unload():
     with gdxpds.gdx.GdxFile() as f:
         f.read(gdx_file)
         assert not f['startupfuel'].loaded
-        assert not f['startupfuel'].dataframe.empty  # loads df
+        with pytest.raises(gdxpds.gdx.Error):
+            print(f['startupfuel'].dataframe)
+
+        f['startupfuel'].load()
         assert f['startupfuel'].loaded
+        assert not f['startupfuel'].dataframe.empty
         assert 'CC' in f['startupfuel'].dataframe['*'].tolist()
 
         f['startupfuel'].unload()
         assert not f['startupfuel'].loaded
-
-        f['startupfuel'].load()  # explicitly load this time
+        with pytest.raises(gdxpds.gdx.Error):
+            print(f['startupfuel'].dataframe)
+        
+        f['startupfuel'].load()
         assert f['startupfuel'].loaded
         assert not f['startupfuel'].dataframe.empty
         assert 'CC' in f['startupfuel'].dataframe['*'].tolist()

--- a/gdxpds/test/test_read.py
+++ b/gdxpds/test/test_read.py
@@ -71,18 +71,14 @@ def test_unload():
     with gdxpds.gdx.GdxFile() as f:
         f.read(gdx_file)
         assert not f['startupfuel'].loaded
-        assert f['startupfuel'].dataframe.empty
-
-        f['startupfuel'].load()
+        assert not f['startupfuel'].dataframe.empty  # loads df
         assert f['startupfuel'].loaded
-        assert not f['startupfuel'].dataframe.empty
         assert 'CC' in f['startupfuel'].dataframe['*'].tolist()
 
         f['startupfuel'].unload()
         assert not f['startupfuel'].loaded
-        assert f['startupfuel'].dataframe.empty
-        
-        f['startupfuel'].load()
+
+        f['startupfuel'].load()  # explicitly load this time
         assert f['startupfuel'].loaded
         assert not f['startupfuel'].dataframe.empty
         assert 'CC' in f['startupfuel'].dataframe['*'].tolist()

--- a/gdxpds/test/test_specials.py
+++ b/gdxpds/test/test_specials.py
@@ -75,8 +75,6 @@ def test_roundtrip_just_special_values(manage_rundir):
         ret = gdxcc.gdxOpenWrite(f.H,filename,"gdxpds")
         if not ret:
             raise gdxpds.gdx.GdxError(f.H,"Could not open {} for writing. Consider cloning this file (.clone()) before trying to write".format(repr(filename)))
-        # write the universal set
-        f.universal_set.write()
         if not gdxcc.gdxDataWriteStrStart(f.H,
                                           'special_values',
                                           '',

--- a/gdxpds/test/test_write.py
+++ b/gdxpds/test/test_write.py
@@ -229,7 +229,6 @@ def test_setting_dataframes(manage_rundir):
         #     reset with empty list
         gdx.append(gdxpds.gdx.GdxSymbol('sym_12',gdxpds.gdx.GamsDataType.Set,
             dims=2))
-        gdx[-1].dataframe = gdx[-1].dataframe.copy()
         gdx[-1].dataframe = []
         assert gdx[-1].num_dims == 2
         assert gdx[-1].dims == ['*'] * 2

--- a/gdxpds/test/test_write.py
+++ b/gdxpds/test/test_write.py
@@ -151,17 +151,21 @@ def test_setting_dataframes(manage_rundir):
         # start with WAYS THAT WORK:
         # 0 dims
         #     full dataframe
-        gdx.append(gdxpds.gdx.GdxSymbol('sym_1', gdxpds.gdx.GamsDataType.Parameter, dataframe=pds.DataFrame([[2.0]])))
+        gdx.append(gdxpds.gdx.GdxSymbol('sym_1',gdxpds.gdx.GamsDataType.Parameter))
+        gdx[-1].dataframe = pds.DataFrame([[2.0]])
         assert list(gdx[-1].dataframe.columns) == ['Value']
-        #     edit initialized dataframe - Parameter
-        gdx.append(
-            gdxpds.gdx.GdxSymbol('sym_2', gdxpds.gdx.GamsDataType.Parameter, dataframe=pds.DataFrame({'Value': [5.0]}))
-        )
         #     list of lists
-        df = {key: [default] for key, default in gdxpds.gdx.GAMS_VALUE_DEFAULTS.items()}
-        gdx.append(gdxpds.gdx.GdxSymbol('sym_3',gdxpds.gdx.GamsDataType.Variable, dataframe=df))
-        #     empty list
-        gdx.append(gdxpds.gdx.GdxSymbol('sym_4',gdxpds.gdx.GamsDataType.Parameter, dataframe=pds.DataFrame({'Value': []})))
+        gdx.append(gdxpds.gdx.GdxSymbol('sym_3',gdxpds.gdx.GamsDataType.Variable))
+        values = [3.0]
+        for value_col_name in gdx[-1].value_col_names:
+            if value_col_name == 'Level':
+                continue
+            values.append(gdx[-1].get_value_col_default(value_col_name))
+        gdx[-1].dataframe = [values]
+        #     reset with empty list
+        gdx.append(gdxpds.gdx.GdxSymbol('sym_4',gdxpds.gdx.GamsDataType.Parameter))
+        gdx[-1].dataframe = pds.DataFrame([[1.0]])
+        gdx[-1].dataframe = []
         assert gdx[-1].num_records == 0
 
         # > 0 dims - GdxSymbol initialized with dims=0
@@ -339,7 +343,6 @@ def test_setting_dataframes(manage_rundir):
     with gdxpds.gdx.GdxFile(lazy_load=False) as gdx:
         gdx.read(os.path.join(outdir,'dataframe_set_tests.gdx'))
         assert gdx['sym_1'].num_records == 1
-        assert gdx['sym_2'].num_records == 1
         assert gdx['sym_3'].num_records == 1
         assert gdx['sym_4'].num_records == 1 # GAMS defaults empty 0-dim parameter to 0
         assert gdx['sym_4'].dataframe['Value'].values[0] == 0.0

--- a/gdxpds/test/test_write.py
+++ b/gdxpds/test/test_write.py
@@ -66,7 +66,7 @@ def test_from_scratch_sets(manage_rundir):
         gdx.append(gdxpds.gdx.GdxSymbol('my_other_set',gdxpds.gdx.GamsDataType.Set,dims=['u']))
         data = pds.DataFrame([['u' + str(i)] for i in range(1,11)],columns=['u'])
         data['Value'] = True
-        gdx[-1].dataframe = gdx[-1].dataframe.append(data)        
+        gdx[-1].dataframe = data
         gdx.write(os.path.join(outdir,'my_sets.gdx'))
 
     with gdxpds.gdx.GdxFile(lazy_load=False) as gdx:

--- a/gdxpds/test/test_write.py
+++ b/gdxpds/test/test_write.py
@@ -151,26 +151,17 @@ def test_setting_dataframes(manage_rundir):
         # start with WAYS THAT WORK:
         # 0 dims
         #     full dataframe
-        gdx.append(gdxpds.gdx.GdxSymbol('sym_1',gdxpds.gdx.GamsDataType.Parameter))
-        gdx[-1].dataframe = pds.DataFrame([[2.0]])
+        gdx.append(gdxpds.gdx.GdxSymbol('sym_1', gdxpds.gdx.GamsDataType.Parameter, dataframe=pds.DataFrame([[2.0]])))
         assert list(gdx[-1].dataframe.columns) == ['Value']
         #     edit initialized dataframe - Parameter
-        gdx.append(gdxpds.gdx.GdxSymbol('sym_2',gdxpds.gdx.GamsDataType.Parameter))
-        n = len(gdx[-1].dataframe.columns)
-        gdx[-1].dataframe['Value'] = [5.0] # list is required to specify number of rows to make
-        assert n == len(gdx[-1].dataframe.columns)
+        gdx.append(
+            gdxpds.gdx.GdxSymbol('sym_2', gdxpds.gdx.GamsDataType.Parameter, dataframe=pds.DataFrame({'Value': [5.0]}))
+        )
         #     list of lists
-        gdx.append(gdxpds.gdx.GdxSymbol('sym_3',gdxpds.gdx.GamsDataType.Variable))
-        values = [3.0]
-        for value_col_name in gdx[-1].value_col_names:
-            if value_col_name == 'Level':
-                continue
-            values.append(gdx[-1].get_value_col_default(value_col_name))
-        gdx[-1].dataframe = [values]
-        #     reset with empty list
-        gdx.append(gdxpds.gdx.GdxSymbol('sym_4',gdxpds.gdx.GamsDataType.Parameter))
-        gdx[-1].dataframe = pds.DataFrame([[1.0]])
-        gdx[-1].dataframe = []
+        df = {key: [default] for key, default in gdxpds.gdx.GAMS_VALUE_DEFAULTS.items()}
+        gdx.append(gdxpds.gdx.GdxSymbol('sym_3',gdxpds.gdx.GamsDataType.Variable, dataframe=df))
+        #     empty list
+        gdx.append(gdxpds.gdx.GdxSymbol('sym_4',gdxpds.gdx.GamsDataType.Parameter, dataframe=pds.DataFrame({'Value': []})))
         assert gdx[-1].num_records == 0
 
         # > 0 dims - GdxSymbol initialized with dims=0
@@ -307,6 +298,7 @@ def test_setting_dataframes(manage_rundir):
         with pytest.raises(Exception) as excinfo:
             gdx[-1].dims = ['g','t','d']
         assert "Cannot set dims" in str(excinfo.value)
+        gdx[-1].dataframe = []  # Assign blank so we can write out
         #     dataframe of different number of dims
         gdx.append(gdxpds.gdx.GdxSymbol('sym_20',gdxpds.gdx.GamsDataType.Variable,
             dims=['d','t']))
@@ -327,6 +319,7 @@ def test_setting_dataframes(manage_rundir):
             gdx[-1].dataframe = pds.DataFrame([['1',6.0],
                                               ['2',7.0],
                                               ['3',-12.0]])
+        gdx[-1].dataframe = []  # Assign blank so we can write out
         #     list of lists of varying widths
         gdx.append(gdxpds.gdx.GdxSymbol('sym_22',gdxpds.gdx.GamsDataType.Parameter,
             dims=3))
@@ -340,6 +333,7 @@ def test_setting_dataframes(manage_rundir):
         with pytest.raises(Exception) as e_info:
             gdx[-1].dataframe = [['u1','PV','c0','1',2.5],
                                  ['u1','PV','c0','2',-30.0]]
+        gdx[-1].dataframe = []  # Assign blank so we can write out
 
         gdx.write(os.path.join(outdir,'dataframe_set_tests.gdx'))
 

--- a/gdxpds/write_gdx.py
+++ b/gdxpds/write_gdx.py
@@ -41,7 +41,7 @@ from numbers import Number
 # gdxpds needs to be imported before pandas to try to avoid library conflict on 
 # Linux that causes a segmentation fault.
 from gdxpds.tools import Error
-from gdxpds.gdx import GdxFile, GdxSymbol, GAMS_VALUE_COLS_MAP, GamsDataType
+from gdxpds.gdx import GdxFile, GdxSymbol, GAMS_VALUE_COLS_MAP, GamsDataType, infer_data_type
 
 import pandas as pds
 
@@ -97,47 +97,12 @@ class Translator(object):
         self.gdx.write(path)
 
     def __add_symbol_to_gdx(self, symbol_name, df):
-        data_type, num_dims = self.__infer_data_type(symbol_name,df)
+        data_type, num_dims = infer_data_type(symbol_name,df)
         logger.info("Inferred data type of {} to be {}.".format(symbol_name,data_type.name))
 
         self.__gdx.append(GdxSymbol(symbol_name,data_type,dims=num_dims))
         self.__gdx[symbol_name].dataframe = df
         return
-
-    def __infer_data_type(self,symbol_name,df):
-        """
-        Returns
-        -------
-        (gdxpds.GamsDataType, int)
-            symbol type and number of dimensions implied by df
-        """
-        # See if structure implies that symbol_name may be a Variable or an Equation
-        # If so, break tie based on naming convention--Variables start with upper case, 
-        # equations start with lower case
-        var_or_eqn = False        
-        df_col_names = df.columns
-        var_eqn_col_names = [col_name for col_name, col_ind in GAMS_VALUE_COLS_MAP[GamsDataType.Variable]]
-        if len(df_col_names) >= len(var_eqn_col_names):
-            # might be variable or equation
-            var_or_eqn = True
-            trunc_df_col_names = df_col_names[len(df_col_names) - len(var_eqn_col_names):]
-            for i, df_col in enumerate(trunc_df_col_names):
-                if df_col and (df_col.lower() != var_eqn_col_names[i].lower()):
-                    var_or_eqn = False
-                    break
-            if var_or_eqn:
-                num_dims = len(df_col_names) - len(var_eqn_col_names)
-                if symbol_name[0].upper() == symbol_name[0]:
-                    return GamsDataType.Variable, num_dims
-                else:
-                    return GamsDataType.Equation, num_dims
-
-        # Parameter or set
-        num_dims = len(df_col_names) - 1
-        if len(df.index) > 0:
-            if isinstance(df.loc[df.index[0],df.columns[-1]],Number):
-                return GamsDataType.Parameter, num_dims
-        return GamsDataType.Set, num_dims
 
 
 def to_gdx(dataframes,path=None,gams_dir=None):

--- a/gdxpds/write_gdx.py
+++ b/gdxpds/write_gdx.py
@@ -97,12 +97,7 @@ class Translator(object):
         self.gdx.write(path)
 
     def __add_symbol_to_gdx(self, symbol_name, df):
-        data_type, num_dims = infer_data_type(symbol_name,df)
-        logger.info("Inferred data type of {} to be {}.".format(symbol_name,data_type.name))
-
-        self.__gdx.append(GdxSymbol(symbol_name,data_type,dims=num_dims))
-        self.__gdx[symbol_name].dataframe = df
-        return
+        self.__gdx.append(GdxSymbol.from_df(symbol_name,df))
 
 
 def to_gdx(dataframes,path=None,gams_dir=None):


### PR DESCRIPTION
Improve behaviour of unloaded symbols. Probably needs a couple of iterations of feedback. Breaks backwards compatibility on `GdxSymbol.__init__` so probably worth including this in v2 instead of v1.3. This is somewhat faster and makes it easier to work with unloaded symbols.

## Changes
* Add constructor functions on GdxSymbol for creating from a dataframe and creating from a file. These should be used instead of `__init__` in most use cases.
* `GdxSymbol.__init__` now always returns an unloaded symbol. To read metadata from the file (previous behaviour) use the `from_gdx` constructor.
* Unloaded symbols have `.dataframe=None`, not an empty dataframe. Remove `init_dataframe` as no longer needed.
  * This should improve handling of (correctly) empty symbols
  * Also means that `gdxpds.to_dataframe` on a gdx with many symbols is much faster (20.439 -> 11.088 seconds with 1024 symbols) as we don't need to initialise lots of blank dataframes
* Move infer_data_type out of the Translator class. Seems like a generally useful util (and is used in `GdxSymbol.from_dataframe`). Possibly shouldn't be in gdx.py as this file is too large already
* `GdxSymbol.__init__` defaults to `dims=None`, not `dims=0`. This may improve handling of scalars in future.
* Permit setting dims=None, if dims is already None.
* If dims is unset (None), num_dims should be None not 0. This may improve handling of scalars in future.
* .loaded is dynamically calculated from `.dataframe is not None`. This prevents possible bugs where ._loaded is incorrect.
* Trying to read an unloaded dataframe raises an error instead of returning an empty dataframe.
  * Explicit error is good, breaking compatibility is bad. This is better than silently loading an empty dataframe IMO.

## Tests
* [x] passes pytest
