### PR TITLE
FIX: Check "Value" by position, not by label

### DIFF
--- a/gdxpds/write_gdx.py
+++ b/gdxpds/write_gdx.py
@@ -135,7 +135,7 @@ class Translator(object):
         # Parameter or set
         num_dims = len(df_col_names) - 1
         if len(df.index) > 0:
-            if isinstance(df.loc[df.index[0],df.columns[-1]],Number):
+            if isinstance(df.iloc[0,-1],Number):
                 return GamsDataType.Parameter, num_dims
         return GamsDataType.Set, num_dims
 


### PR DESCRIPTION
The problem is this line: `if isinstance(df.loc[df.index[0],df.columns[-1]],Number):` where we expect a Number (parameter) or a cbool or a str (set), we get an array if df.index[0] matches multiple rows. Switching to locational indexing `iloc` avoids this problem.

Closes #62

Conflicts with #87, but very easy to fix.

## Tests
* [x] Passes pytest
* [x] The test case in #62 now creates a gdx with two Parameters (correct behaviour)