### PR TITLE
Adding function get_data_types to retrieve a map of symbol name to GamsDataType

### DIFF
--- a/gdxpds/__init__.py
+++ b/gdxpds/__init__.py
@@ -47,5 +47,5 @@ except:
                    "before importing pandas to avoid a library conflict.")
 
 
-from gdxpds.read_gdx import to_dataframes, list_symbols, to_dataframe
+from gdxpds.read_gdx import to_dataframes, list_symbols, to_dataframe, get_data_types
 from gdxpds.write_gdx import to_gdx

--- a/gdxpds/read_gdx.py
+++ b/gdxpds/read_gdx.py
@@ -4,7 +4,7 @@ import logging
 # gdxpds needs to be imported before pandas to try to avoid library conflict on 
 # Linux that causes a segmentation fault.
 from gdxpds.tools import Error
-from gdxpds.gdx import GdxFile
+from gdxpds.gdx import GdxFile, GamsDataType
 
 logger = logging.getLogger(__name__)
 
@@ -47,7 +47,7 @@ class Translator(object):
     def dataframes(self):
         if self.__dataframes is None:
             self.__dataframes = OrderedDict()
-            for symbol in self.__gdx:
+            for symbol in self.gdx:
                 if not symbol.loaded:
                     symbol.load()
                 self.__dataframes[symbol.name] = symbol.dataframe.copy()
@@ -55,7 +55,11 @@ class Translator(object):
 
     @property
     def symbols(self):
-        return [symbol_name for symbol_name in self.gdx]
+        return [symbol.name for symbol in self.gdx]
+    
+    @property
+    def data_types(self):
+        return {symbol.name: symbol.data_type for symbol in self.gdx}
 
     def dataframe(self, symbol_name):
         if not symbol_name in self.gdx:
@@ -64,6 +68,7 @@ class Translator(object):
             self.gdx[symbol_name].load()
         # This was returning { symbol_name: dataframe }, which seems intuitively off.
         return self.gdx[symbol_name].dataframe.copy()
+
 
 def to_dataframes(gdx_file,gams_dir=None):
     """
@@ -82,8 +87,8 @@ def to_dataframes(gdx_file,gams_dir=None):
         Returns a dict of Pandas DataFrames, one item for each symbol in the GDX
         file, keyed with the symbol name.
     """
-    dfs = Translator(gdx_file,gams_dir=gams_dir).dataframes
-    return dfs
+    return Translator(gdx_file,gams_dir=gams_dir).dataframes
+
 
 def list_symbols(gdx_file,gams_dir=None):
     """
@@ -101,8 +106,27 @@ def list_symbols(gdx_file,gams_dir=None):
     list of str
         List of symbol names
     """
-    symbols = Translator(gdx_file,gams_dir=gams_dir,lazy_load=True).symbols
-    return symbols
+    return Translator(gdx_file,gams_dir=gams_dir,lazy_load=True).symbols
+
+
+def get_data_types(gdx_file,gams_dir=None):
+    """
+    Returns a dict of the symbols' :py:class:`GamsDataTypes <GamsDataType>`.
+    
+    Parameters
+    ----------
+    gdx_file : pathlib.Path or str
+        Path to the GDX file to read
+    gams_dir : None or pathlib.Path or str
+        optional path to GAMS directory
+
+    Returns
+    -------
+    dict of str to :py:class:GamsDataType`
+        Map of symbol names to the corresponding :py:class:GamsDataType`
+    """
+    return Translator(gdx_file,gams_dir=gams_dir,lazy_load=True).data_types
+
 
 def to_dataframe(gdx_file,symbol_name,gams_dir=None,old_interface=True):
     """

--- a/gdxpds/test/test_read.py
+++ b/gdxpds/test/test_read.py
@@ -4,7 +4,7 @@ import os
 import pytest
 
 import gdxpds.gdx
-from gdxpds import to_dataframes
+from gdxpds import to_dataframes, list_symbols, get_data_types
 from gdxpds.test import base_dir
 
 logger = logging.getLogger(__name__)
@@ -26,7 +26,23 @@ def test_read_path():
     filename = 'all_generator_properties_input.gdx'
     from pathlib import Path
     gdx_file = Path(base_dir) / filename
-    to_dataframes(gdx_file)
+    
+    symbol_names = list_symbols(gdx_file)
+    n = len(symbol_names) 
+    assert isinstance(symbol_names[0], str)
+    assert n == 7
+    
+    dfs = to_dataframes(gdx_file)
+    assert len(dfs) == n
+
+    # data frames are loaded in order
+    for i, symbol_name in enumerate(dfs):
+        assert symbol_names[i] == symbol_name
+
+    dtypes = get_data_types(gdx_file)
+    # this file is all parameters
+    for val in dtypes.values():
+        val == gdxpds.gdx.GamsDataType.Parameter
 
 def test_unload():
     filename = 'all_generator_properties_input.gdx'


### PR DESCRIPTION
The new function get_data_types can be used in conjunction with to_dataframes to make code aware of the expected data type in the Value column. (E.g., floats unless GamsDataType.Set).

This PR also fixes list_symbols to actually return a list of str as is stated in the documentation. It was incorrectly returning a list of gdx.GdxSymbol objects.