### PR TITLE
fix: encode GAMS EPS as np.finfo(float).tiny (closes #39)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,12 @@
+v4.0.0, 05/27/26 -- BREAKING: GAMS EPS is now encoded as numpy.finfo(float).tiny
+                    (~2.22e-308), not numpy.finfo(float).eps (machine epsilon,
+                    ~2.22e-16). EPS detection is exact equality on the sentinel,
+                    so a legitimate small float (e.g. 1e-200) now round-trips as
+                    itself instead of silently mapping to GAMS EPS on write
+                    (closes #39). If you wrote numpy.finfo(float).eps to mean
+                    GAMS EPS, switch to numpy.finfo(float).tiny;
+                    gdxpds.special.NUMPY_SPECIAL_VALUES[-1] is always the
+                    canonical sentinel
 v3.1.0, 05/27/26 -- large read/write perf and memory wins on both engines; on a 5M-row
                     synthetic Parameter the gdxcc write peak drops ~358 MB -> ~129 MB
                     and gdxcc-read drops ~2.4 GB -> ~1.5 GB. Closes #113 and #65

--- a/doc/source/overview.md
+++ b/doc/source/overview.md
@@ -9,7 +9,7 @@ There are two main ways to use gdxpds. The first use case is the one that was in
 The two primary points of reference for the direct conversion utilities are GDX files on disk and Python dicts of `{symbol_name: pandas.DataFrame}`, where each `pandas.DataFrame` contains data for a single set, parameter, equation, variable, or alias. The shape of the value columns depends on the symbol {py:data}`gdxpds.gdx.GamsDataType`:
 
 - **Sets and Aliases** have a single `Value` column whose entries are the GAMS *element text* string, with `""` denoting a member that has no text. Membership is conveyed by **row presence**: every row is a member. On write, the value column can be omitted, given as booleans (any value whether `True` or `False` means "member, no text"), or given as text strings.
-- **Parameters** have a single `Value` column of type `float`; the GAMS specials `NA`, `UNDEF`, `+Inf` / `-Inf`, and `EPS` map to `numpy.nan`, `None`, `numpy.inf` / `-numpy.inf`, and `numpy.finfo(float).eps` (see [Special values](#special-values)).
+- **Parameters** have a single `Value` column of type `float`; the GAMS specials `NA`, `UNDEF`, `+Inf` / `-Inf`, and `EPS` map to `numpy.nan`, `None`, `numpy.inf` / `-numpy.inf`, and `numpy.finfo(float).tiny` (see [Special values](#special-values)).
 - **Variables and Equations** have five value columns — level, marginal, lower, upper, scale — as enumerated in {py:class}`gdxpds.gdx.GamsValueType`; see {py:data}`gdxpds.gdx.GAMS_VALUE_COLS_MAP`.
 
 Aliases reuse their parent's records (on read they look like the Set they alias) and their parent relationship is carried separately; see [Aliases](#aliases) and the `aliases=` example below.
@@ -178,8 +178,8 @@ with GdxFile() as gdx:
     )
 
     # A Parameter with one Special value (UNDEF is None on read/write). See
-    # "Special values" -- np.nan, np.inf, -np.inf, and machine epsilon also
-    # round-trip via the same mapping.
+    # "Special values" -- np.nan, np.inf, -np.inf, and np.finfo(float).tiny
+    # also round-trip via the same mapping.
     append_parameter(
         gdx, 'p',
         pd.DataFrame({
@@ -409,23 +409,25 @@ In the value columns of Parameters, Variables, and Equations, GAMS's special val
 | `NA` | `numpy.nan` |
 | `UNDEF` | `None` |
 | `+Inf` / `-Inf` | `numpy.inf` / `-numpy.inf` |
-| `EPS` | machine epsilon (`numpy.finfo(float).eps`) |
+| `EPS` | `numpy.finfo(float).tiny` (smallest normal positive float, ~2.22e-308) |
 
 Both I/O engines preserve all of these on write, so they round-trip unchanged.
+
+EPS detection is exact equality on the sentinel: only `numpy.finfo(float).tiny` maps to GAMS `EPS` on write. Other small floats (`1e-200`, machine epsilon, etc.) survive as-is. In v3.x and earlier, the sentinel was `numpy.finfo(float).eps` (~2.22e-16) and any value below it silently became `EPS` (#39).
 
 :::{tip}
 If you would rather **not** keep `EPS` values, drop them yourself before writing — there is no write-time option, so the transformation stays explicit and engine-independent:
 
 ```python
 import numpy as np
-eps = np.finfo(float).eps
+eps = np.finfo(float).tiny
 df['Value'] = df['Value'].replace(eps, 0.0)   # treat EPS as plain zero
 ```
 :::
 
-## Migration from 1.x / 2.x
+## Migration from 1.x / 2.x / 3.x
 
-Releases 2.0.0 and 3.0.0 each made breaking changes. In v2.0.0, old interfaces were removed for `to_dataframe` and accessing the `csv_to_gdx` and `gdx_to_csv` scripts. Version 3.0.0 switches the default engine to `gams.transfer` (from `gdxcc`) and supports set text and aliases as first-class features. Additional details and other breaking changes:
+Releases 2.0.0, 3.0.0, and 4.0.0 each made breaking changes. In v2.0.0, old interfaces were removed for `to_dataframe` and accessing the `csv_to_gdx` and `gdx_to_csv` scripts. Version 3.0.0 switches the default engine to `gams.transfer` (from `gdxcc`) and supports set text and aliases as first-class features. Version 4.0.0 fixes the GAMS `EPS` encoding so legitimate small floats no longer round-trip as `EPS`. Additional details and other breaking changes:
 
 ### v2.0.0 breaking changes
 
@@ -440,6 +442,10 @@ Releases 2.0.0 and 3.0.0 each made breaking changes. In v2.0.0, old interfaces w
 - **`load_set_text` is removed.** Element text is always read and written, so drop the argument from any `to_dataframe` / `to_dataframes` / `GdxSymbol.load` / `GdxFile.load_all` / `load_symbols` calls.
 - **`GdxFile.H` is removed.** If you drove raw `gdxcc` calls through it, use `gdx_file._engine_impl.handle` instead.
 - **GDX UNDEF is preserved on write** (round-trips as `None`) instead of collapsing to `0.0`.
+
+### v4.0.0 breaking changes
+
+- **GAMS `EPS` is now encoded as `numpy.finfo(float).tiny`** (~2.22e-308), the smallest normal positive float, not `numpy.finfo(float).eps` (machine epsilon, ~2.22e-16). EPS detection is exact equality on this sentinel, so a legitimate small float (`1e-200`, machine epsilon, etc.) now round-trips as itself instead of silently mapping to GAMS `EPS` (#39). If your code wrote `numpy.finfo(float).eps` to mean GAMS `EPS`, switch to `numpy.finfo(float).tiny`; `gdxpds.special.NUMPY_SPECIAL_VALUES[-1]` is always the canonical sentinel.
 
 ## Configuration
 

--- a/src/gdxpds/__init__.py
+++ b/src/gdxpds/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "3.1.0"
+__version__ = "4.0.0"
 
 from gdxpds._engine import Engine, EngineError
 from gdxpds.gdx import DomainError, GdxError, SymbolNotFoundError, TransferError

--- a/src/gdxpds/_gdxcc_engine.py
+++ b/src/gdxpds/_gdxcc_engine.py
@@ -65,7 +65,7 @@ def _gdx_to_np_svs(arr: np.ndarray) -> np.ndarray:
         NA    -> ``np.nan``
         +Inf  -> ``np.inf``
         -Inf  -> ``-np.inf``
-        EPS   -> ``np.finfo(float).eps``
+        EPS   -> ``np.finfo(float).tiny``
     """
     undef_mf, na_mf, pinf_mf, ninf_mf, eps_mf = (special.SPECIAL_VALUES[i] for i in range(5))
     eps = special.NUMPY_SPECIAL_VALUES[-1]
@@ -134,9 +134,10 @@ def _coerce_value_col(col_data: pd.Series, n_rows: int) -> np.ndarray:
     nan_mask = np.isnan(arr)
     pinf_mask = arr == np.inf
     ninf_mask = arr == -np.inf
-    # NaN values fall out of the eps band naturally: arr - eps is NaN for NaN
-    # entries, and `np.abs(NaN) < eps` is False.
-    eps_mask = np.abs(arr - eps) < eps
+    # Exact equality on the EPS sentinel: a legitimate small float (e.g.
+    # 1e-200) must not silently map to GAMS EPS on write (#39). NaN naturally
+    # falls out of the comparison (NaN == x is always False).
+    eps_mask = arr == eps
     arr[nan_mask] = special.SPECIAL_VALUES[1]  # GDX NA
     arr[pinf_mask] = special.SPECIAL_VALUES[2]  # GDX +Inf
     arr[ninf_mask] = special.SPECIAL_VALUES[3]  # GDX -Inf

--- a/src/gdxpds/_transfer_engine.py
+++ b/src/gdxpds/_transfer_engine.py
@@ -73,18 +73,23 @@ def _substitute_value_col(col_data: pd.Series) -> np.ndarray:
     """Return a fresh ``float64`` ndarray with gdxpds-canonical special values
     pre-substituted to the gams.transfer encoding.
 
-    Inverse of :func:`_convert_transfer_specials`: machine eps -> EPS (gt's
-    ``-0.0``); NaN -> NA (gt's NA sentinel); +/-inf already match. Genuine 0.0
-    is left alone (only eps maps to EPS). GDX UNDEF is gdxpds' canonical
-    ``None`` (see :data:`special.NUMPY_SPECIAL_VALUES`), only possible in an
-    object column; it maps to ``gt.SpecialValues.UNDEF``, distinct from NA
-    (``np.nan``) which the float64 coercion would otherwise produce.
+    Inverse of :func:`_convert_transfer_value_col`: the EPS sentinel
+    (:data:`special.NUMPY_SPECIAL_VALUES[-1]`, ``np.finfo(float).tiny``) ->
+    ``gt.SpecialValues.EPS``, which is the negative-zero bit pattern (so
+    distinguishable from genuine ``+0.0`` only by the sign bit, not by
+    ``==``); NaN -> NA (gt's NA sentinel); +/-inf already match. Genuine 0.0
+    is left alone. GDX UNDEF is gdxpds' canonical ``None``, only possible
+    in an object column; it maps to ``gt.SpecialValues.UNDEF``, distinct
+    from NA (``np.nan``) which the float64 coercion would otherwise produce.
+
+    EPS detection is exact equality on the sentinel: a legitimate small float
+    (e.g. ``1e-200``) must not silently map to GAMS EPS on write (#39).
 
     Returns a NEW ndarray so the caller can attach it to a separate DataFrame
     without modifying the source (the source frame's columns stay views into
     the user's data, keeping the per-symbol allocation small).
     """
-    eps = NUMPY_SPECIAL_VALUES[-1]
+    eps_sv = NUMPY_SPECIAL_VALUES[-1]
     is_none: np.ndarray | None = None
     if col_data.dtype == object:
         # Cheap-out: only object columns can carry a Python ``None`` (the
@@ -94,7 +99,7 @@ def _substitute_value_col(col_data: pd.Series) -> np.ndarray:
         col_arr = col_data.to_numpy()
         is_none = np.fromiter((v is None for v in col_arr), dtype=bool, count=len(col_data))
     arr = col_data.to_numpy(dtype="float64", copy=True)
-    is_eps = np.abs(arr - eps) < eps
+    is_eps = arr == eps_sv
     nan_mask = np.isnan(arr)
     arr[nan_mask] = gt.SpecialValues.NA
     arr[is_eps] = gt.SpecialValues.EPS
@@ -130,9 +135,12 @@ def _convert_transfer_value_col(col_data: pd.Series) -> np.ndarray:
     """Map gams.transfer special-value encodings on a single value column to
     the gdxpds canonical form, returning a fresh ndarray.
 
-    EPS (gt's ``-0.0``) -> machine eps; NA (gt's NA sentinel) -> ``np.nan``;
-    UNDEF (gt's distinct NaN bit pattern) -> ``None``; +/-inf already match.
-    Genuine ``0.0`` is left alone (only negative zero is EPS).
+    EPS (gt's negative-zero bit pattern, ``gt.SpecialValues.EPS == -0.0``) ->
+    the EPS sentinel (``np.finfo(float).tiny``); NA (gt's NA sentinel) ->
+    ``np.nan``; UNDEF (gt's distinct NaN bit pattern) -> ``None``; +/-inf
+    already match. Genuine ``+0.0`` is left alone -- only negative zero is
+    EPS, and ``gt.SpecialValues.isEps`` distinguishes the two via the sign
+    bit (Python ``==`` would conflate them).
 
     UNDEF is kept distinct from NA, matching the gdxcc engine: gdxcc maps GDX
     UNDEF -> ``None`` and GDX NA -> ``np.nan``. A column carrying any UNDEF

--- a/src/gdxpds/special.py
+++ b/src/gdxpds/special.py
@@ -5,10 +5,16 @@ import numpy as np
 logger = logging.getLogger(__name__)
 
 
-#                      1E300,  2E300,  3E300,   4E300,               5E300
-NUMPY_SPECIAL_VALUES = [None, np.nan, np.inf, -np.inf, np.finfo(float).eps]
+#                      1E300,  2E300,  3E300,   4E300,                5E300
+NUMPY_SPECIAL_VALUES = [None, np.nan, np.inf, -np.inf, np.finfo(float).tiny]
 """List of numpy special values in gdxGetSpecialValues order, i.e.,
-[None, np.nan, np.inf, -np.inf, np.finfo(float).eps]
+[None, np.nan, np.inf, -np.inf, np.finfo(float).tiny]
+
+GAMS EPS is the GAMS "infinitesimal" -- a non-zero value distinct from 0 -- so
+we encode it on the numpy side as ``np.finfo(float).tiny`` (smallest normal
+positive float, ~2.22e-308). v3.x and earlier used ``np.finfo(float).eps``
+(machine epsilon, ~2.22e-16); that was conceptually wrong, and it silently
+mapped any legitimate small float ``<= eps`` to GAMS EPS on write. See #39.
 """
 
 
@@ -55,9 +61,13 @@ def is_np_eps(val):
     Returns
     -------
     bool
-        True if val is equal to eps (np.finfo(float).eps), False otherwise
+        True if val is exactly the numpy encoding of GAMS EPS
+        (:data:`NUMPY_SPECIAL_VALUES[-1]`, i.e. ``np.finfo(float).tiny``);
+        False otherwise. Exact equality (no tolerance band): only the
+        sentinel maps to GAMS EPS, so legitimate small floats like ``1e-200``
+        round-trip as themselves.
     """
-    return np.abs(val - NUMPY_SPECIAL_VALUES[-1]) < NUMPY_SPECIAL_VALUES[-1]
+    return val == NUMPY_SPECIAL_VALUES[-1]
 
 
 def is_np_sv(val):
@@ -100,10 +110,11 @@ def convert_np_to_gdx_svs(df, num_dims):
     # fillna and apply map to value columns, then merge with dimensional columns
     try:
         values = tmp.iloc[:, num_dims:].replace(NP_TO_GDX_SVS, value=None)
-        # DataFrame.replace is generally not sufficient to identify EPS values
-        values[(values - NUMPY_SPECIAL_VALUES[-1]).abs() < NUMPY_SPECIAL_VALUES[-1]] = (
-            SPECIAL_VALUES[4]
-        )
+        # ``DataFrame.replace`` on the float-keyed NP_TO_GDX_SVS doesn't always
+        # match the EPS sentinel under pandas' float-equality rules, so detect
+        # the sentinel explicitly. Exact equality: a legitimate small float
+        # (e.g. 1e-200) must not silently map to GAMS EPS (#39).
+        values[values == NUMPY_SPECIAL_VALUES[-1]] = SPECIAL_VALUES[4]
         tmp = (tmp.iloc[:, :num_dims]).merge(values, left_index=True, right_index=True)
     except Exception:
         logger.error(

--- a/tests/test_engine_parity.py
+++ b/tests/test_engine_parity.py
@@ -53,7 +53,7 @@ def test_read_parity(data_dir, fixture):
 def test_read_parity_special_values():
     # Write a Parameter carrying each producible special value via the gdxcc
     # write path, then assert both engines read it back identically.
-    eps = np.finfo(float).eps
+    eps = np.finfo(float).tiny  # gdxpds' numpy encoding of GAMS EPS
     df = pd.DataFrame(
         {"i": ["a", "b", "c", "d", "e", "f"], "Value": [np.nan, np.inf, -np.inf, eps, 0.0, 1.5]}
     )
@@ -139,7 +139,7 @@ def test_write_parity(data_dir, fixture, tmp_path):
 
 
 def test_write_parity_special_values(tmp_path):
-    eps = np.finfo(float).eps
+    eps = np.finfo(float).tiny  # gdxpds' numpy encoding of GAMS EPS
     dfs = {
         "p": pd.DataFrame(
             {"i": ["a", "b", "c", "d", "e"], "Value": [np.nan, np.inf, -np.inf, eps, 0.0]}
@@ -147,6 +147,30 @@ def test_write_parity_special_values(tmp_path):
         "scalar": pd.DataFrame({"Value": [42.0]}),
     }
     _assert_matrix_consistent(_write_read_matrix(dfs, tmp_path))
+
+
+def test_write_parity_small_floats_not_eps(tmp_path):
+    """Regression for #39: small floats below v3.x's machine-epsilon EPS band
+    survive the write/read round-trip as themselves through both engines.
+
+    Previously these would silently map to GAMS EPS and read back as
+    ``np.finfo(float).eps``; now only the exact ``np.finfo(float).tiny``
+    sentinel maps to EPS.
+    """
+    small_eps = np.finfo(float).eps
+    dfs = {
+        "p": pd.DataFrame(
+            {
+                "i": ["a", "b", "c", "d"],
+                "Value": [1e-200, small_eps, 1e-100, 1.5],
+            }
+        )
+    }
+    matrix = _write_read_matrix(dfs, tmp_path)
+    _assert_matrix_consistent(matrix)
+    for dfs_out in matrix.values():
+        vals = dfs_out["p"]["Value"].tolist()
+        assert vals == [1e-200, small_eps, 1e-100, 1.5]
 
 
 def test_write_parity_undef(tmp_path):

--- a/tests/test_specials.py
+++ b/tests/test_specials.py
@@ -133,16 +133,37 @@ def test_special_integrity():
 
 
 def test_numpy_eps():
-    assert gdxpds.special.is_np_eps(np.finfo(float).eps)
+    # v4+: GAMS EPS encodes as np.finfo(float).tiny (smallest normal positive
+    # float). Exact equality only: legitimate small floats like machine
+    # epsilon, 1e-200, etc. must NOT match (#39).
+    assert gdxpds.special.is_np_eps(np.finfo(float).tiny)
     assert not gdxpds.special.is_np_eps(0.0)
-    assert not gdxpds.special.is_np_eps(2.0 * np.finfo(float).eps)
+    assert not gdxpds.special.is_np_eps(2.0 * np.finfo(float).tiny)
+    assert not gdxpds.special.is_np_eps(np.finfo(float).eps)
+    assert not gdxpds.special.is_np_eps(1e-200)
 
 
 def test_convert_np_to_gdx_svs_eps():
     test_df = pd.DataFrame(
-        [["a", np.finfo(float).eps], ["b", 0.0], ["c", 2.0 * np.finfo(float).eps]],
+        [["a", np.finfo(float).tiny], ["b", 0.0], ["c", 2.0 * np.finfo(float).tiny]],
         columns=["A", "Value"],
     )
     result_df = gdxpds.special.convert_np_to_gdx_svs(test_df, num_dims=1)
-    expected_df = pd.Series([gdxpds.special.SPECIAL_VALUES[4], 0.0, 2.0 * np.finfo(float).eps])
+    expected_df = pd.Series([gdxpds.special.SPECIAL_VALUES[4], 0.0, 2.0 * np.finfo(float).tiny])
     assert result_df["Value"].equals(expected_df)
+
+
+def test_small_float_is_not_eps():
+    """Regression for #39: legitimate small floats survive the write/read
+    round-trip as themselves, not as GAMS EPS."""
+    test_df = pd.DataFrame(
+        [["a", 1e-200], ["b", np.finfo(float).eps], ["c", 1e-100]],
+        columns=["A", "Value"],
+    )
+    result_df = gdxpds.special.convert_np_to_gdx_svs(test_df, num_dims=1)
+    # None of these should have been mapped to the GAMS EPS magic float
+    # (SPECIAL_VALUES[4]); they pass through as ordinary small floats.
+    assert (result_df["Value"].to_numpy() != gdxpds.special.SPECIAL_VALUES[4]).all()
+    assert result_df["Value"].iloc[0] == 1e-200
+    assert result_df["Value"].iloc[1] == np.finfo(float).eps
+    assert result_df["Value"].iloc[2] == 1e-100

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -426,7 +426,7 @@ def test_write_known_value_columns(run_dir):
     scratch with known, non-default values in every value column; write, read
     back, and assert the exact values and types survive. (Existing tests only
     wrote default value-column values.)"""
-    eps = np.finfo(float).eps
+    eps = np.finfo(float).tiny  # gdxpds' numpy encoding of GAMS EPS
     outdir = os.path.join(run_dir, "known_value_columns")
     if not os.path.exists(outdir):
         os.mkdir(outdir)


### PR DESCRIPTION
## Summary

- **BREAKING**: `gdxpds.special.NUMPY_SPECIAL_VALUES[-1]` is now `np.finfo(float).tiny` (~2.22e-308), not `np.finfo(float).eps` (machine epsilon, ~2.22e-16). EPS detection is exact equality on the sentinel, so a legitimate small float (e.g. `1e-200`, machine epsilon) now round-trips as itself instead of silently mapping to GAMS `EPS` on write. Closes #39.
- Migration: if you wrote `numpy.finfo(float).eps` to mean GAMS `EPS`, switch to `numpy.finfo(float).tiny`. `gdxpds.special.NUMPY_SPECIAL_VALUES[-1]` is always the canonical sentinel.
- Bumps to v4.0.0. Implements Item D of `dev/modernization-wrapup.md`, the final release in the modernization arc.

## What changed

- `src/gdxpds/special.py`: `NUMPY_SPECIAL_VALUES[-1] = np.finfo(float).tiny`; `is_np_eps` and `convert_np_to_gdx_svs` use exact equality on the sentinel (no more `|val - eps| < eps` band).
- `src/gdxpds/_gdxcc_engine.py` `_coerce_value_col`: write-side `eps_mask = arr == eps` (exact equality); docstring updated.
- `src/gdxpds/_transfer_engine.py` `_substitute_value_col`: same exact-equality switch; docstrings now make explicit that `gt.SpecialValues.EPS` is the negative-zero bit pattern (distinguishable from `+0.0` only via the sign bit, not `==`).
- Tests: `tests/test_specials.py`, `tests/test_engine_parity.py`, `tests/test_write.py` all swap `eps` → `tiny`. New regressions: `test_small_float_is_not_eps` and `test_write_parity_small_floats_not_eps` (`1e-200` survives the full 2x2 write x read engine matrix).
- Docs: `doc/source/overview.md` special-values table, "drop EPS" snippet, intro paragraph, and a new "v4.0.0 breaking changes" subsection in the migration section.
- `CHANGES.txt`: v4.0.0 entry.
- `src/gdxpds/__init__.py`: `__version__ = "4.0.0"`.

## Test plan

- [x] Lint (`ruff check` + `ruff format --check`) clean.
- [x] `pytest tests` passes on `.venv-gams-34` (pandas 3.0).
- [x] `pytest tests` passes on `.venv-gams-49` (pandas 2.2, gamsapi 49.6.0).
- [x] `pytest tests` passes on `.venv-gams-51` (pandas 2.2, gamsapi 51.3.0).
- [x] `.venv-no-gams` wheel build + `gdxpds info` succeed as expected.
- [x] `1e-200` write/read round-trip preserved on both engines (covered by the new regressions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)